### PR TITLE
Resolve contract upgrades and onlyOwner replace onlyManager

### DIFF
--- a/mcs/evm/contracts/MAPCrossChainServiceRelayProxy.sol
+++ b/mcs/evm/contracts/MAPCrossChainServiceRelayProxy.sol
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-
-
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";

--- a/mcs/evm/contracts/MAPCrossChainServiceRelayProxy.sol
+++ b/mcs/evm/contracts/MAPCrossChainServiceRelayProxy.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+
+
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+contract MAPCrossChainServiceRelayProxy is ERC1967Proxy {
+    constructor(address _logic, bytes memory _data)
+    payable
+    ERC1967Proxy(_logic, _data)
+    {
+        require(address(_logic) != address(0),"_logic zero address");
+    }
+}

--- a/mcs/evm/contracts/MapCrossChainService.sol
+++ b/mcs/evm/contracts/MapCrossChainService.sol
@@ -1,17 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-
-
-
-
-
-
-
-
-
-
-
-
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";

--- a/mcs/evm/contracts/MapCrossChainService.sol
+++ b/mcs/evm/contracts/MapCrossChainService.sol
@@ -1,35 +1,48 @@
 // SPDX-License-Identifier: MIT
 
+
+
+
+
+
+
+
+
+
+
+
+
 pragma solidity ^0.8.0;
 
+import "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts/security/Pausable.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "./interface/IWToken.sol";
 import "./interface/IMAPToken.sol";
-import "./utils/Role.sol";
 import "./interface/IFeeCenter.sol";
 import "./utils/TransferHelper.sol";
 import "./interface/IMCS.sol";
 import "./interface/ILightNode.sol";
 import "./utils/RLPReader.sol";
 
-contract MapCrossChainService is ReentrancyGuard, Ownable, Initializable, Pausable, IMCS {
+contract MapCrossChainService is ReentrancyGuard, Initializable, Pausable, IMCS,UUPSUpgradeable {
     using SafeMath for uint;
     using RLPReader for bytes;
     using RLPReader for RLPReader.RLPItem;
 
     uint public nonce;
-
     IERC20 public mapToken;
     ILightNode public lightNode;
     address public wToken;          // native wrapped token
 
     uint public immutable selfChainId = block.chainid;
+    uint public nearChainId;
 
     mapping(bytes32 => address) public tokenRegister;
     //Gas transfer fee charged by the target chain
@@ -62,23 +75,24 @@ contract MapCrossChainService is ReentrancyGuard, Ownable, Initializable, Pausab
         uint fromChain, uint toChain, bytes data);
 
     event mapTokenRegister(bytes32 tokenID, address token);
-    event mapDepositOut(address token, bytes from, address to, bytes32 orderId, uint256 amount);
+    event mapDepositOut(address token, bytes from, bytes32 orderId, address to, uint256 amount);
 
 
     //bytes32 public mapTransferOutTopic = keccak256(bytes('mapTransferOut(address,address,bytes32,uint,uint,bytes,uint,bytes)'));
-    bytes32 public mapTransferOutTopic = keccak256(abi.encodePacked("mapTransferOut(bytes,bytes,bytes32,uint256,uint256,bytes,uint256,bytes)"));
+    bytes32 public constant mapTransferOutTopic = keccak256(abi.encodePacked("mapTransferOut(bytes,bytes,bytes32,uint256,uint256,bytes,uint256,bytes)"));
     //    bytes mapTransferInTopic = keccak256(bytes('mapTransferIn(address,address,bytes32,uint,uint,bytes,uint,bytes)'));
 
     function initialize(address _wToken, address _mapToken, address _lightNode) public initializer {
         wToken = _wToken;
+        nearChainId = 1313161555;
         mapToken = IERC20(_mapToken);
         lightNode = ILightNode(_lightNode);
+        _changeAdmin(msg.sender);
     }
 
     receive() external payable {
         require(msg.sender == wToken, "only wToken");
     }
-
 
     modifier checkOrder(bytes32 orderId) {
         require(!orderList[orderId], "order exist");
@@ -88,6 +102,11 @@ contract MapCrossChainService is ReentrancyGuard, Ownable, Initializable, Pausab
 
     modifier checkCanBridge(address token, uint chainId) {
         require(canBridgeToken[token][chainId], "token not can bridge");
+        _;
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == _getAdmin(), "lightnode :: only admin");
         _;
     }
 
@@ -127,6 +146,11 @@ contract MapCrossChainService is ReentrancyGuard, Ownable, Initializable, Pausab
         canBridgeToken[token][chainId] = canBridge;
     }
 
+    function setChainId(uint256 _id) public onlyOwner {
+        require(_id > 0,"id error");
+        nearChainId = _id;
+    }
+
 
     function transferIn(uint, bytes memory receiptProof) external override nonReentrant whenNotPaused {
         (bool sucess,string memory message,bytes memory logArray) = lightNode.verifyProofData(receiptProof);
@@ -160,6 +184,11 @@ contract MapCrossChainService is ReentrancyGuard, Ownable, Initializable, Pausab
     whenNotPaused
     checkCanBridge(token, toChain)
     {
+        if(toChain == nearChainId){
+            require(toAddress.length >=2 || toAddress.length <= 64,"near address error");
+        }else {
+            require(toAddress.length == 20,"address error");
+        }
         bytes32 orderId = getOrderID(token, msg.sender, toAddress, amount, toChain);
         require(IERC20(token).balanceOf(msg.sender) >= amount, "balance too low");
         if (checkAuthToken(token)) {
@@ -175,6 +204,11 @@ contract MapCrossChainService is ReentrancyGuard, Ownable, Initializable, Pausab
     external override payable
     whenNotPaused
     checkCanBridge(address(0), toChain) {
+        if(toChain == nearChainId){
+            require(toAddress.length >=2 || toAddress.length <= 64,"near address error");
+        }else {
+            require(toAddress.length == 20,"address error");
+        }
         uint amount = msg.value;
         require(amount > 0, "balance is zero");
         bytes32 orderId = getOrderID(address(0), msg.sender, toAddress, amount, toChain);
@@ -188,7 +222,7 @@ contract MapCrossChainService is ReentrancyGuard, Ownable, Initializable, Pausab
         bytes32 orderId = getOrderID(token, from, _addressToBytes(to), amount, 22776);
         //        require(IERC20(token).balanceOf(from) >= amount, "balance too low");
         TransferHelper.safeTransferFrom(token, from, address(this), amount);
-        emit mapDepositOut(token, _addressToBytes(from), to, orderId, amount);
+        emit mapDepositOut(token, _addressToBytes(from),orderId,to,amount);
     }
 
     function depositOutNative(address from, address to) external override payable whenNotPaused {
@@ -196,22 +230,9 @@ contract MapCrossChainService is ReentrancyGuard, Ownable, Initializable, Pausab
         uint amount = msg.value;
         bytes32 orderId = getOrderID(address(0), from, _addressToBytes(to), amount, 22776);
         require(msg.value >= amount, "balance too low");
-        emit mapDepositOut(address(0), _addressToBytes(from), to, orderId, amount);
+        IWToken(wToken).deposit{value : amount}();
+        emit mapDepositOut(address(0), _addressToBytes(from),orderId, to, amount);
     }
-
-    function transferInVault(address token, bytes memory from, address payable to, uint amount, bytes32 orderId, uint fromChain, uint toChain)
-    external checkOrder(orderId) nonReentrant whenNotPaused {
-        if (token == address(0)) {
-            TransferHelper.safeWithdraw(wToken, amount);
-            TransferHelper.safeTransferETH(to, amount);
-        } else if (checkAuthToken(token)) {
-            IMAPToken(token).mint(to, amount);
-        } else {
-            TransferHelper.safeTransfer(token, to, amount);
-        }
-        emit mapTransferIn(token, from, orderId, fromChain, toChain, to, amount);
-    }
-
 
     function _transferIn(address token, bytes memory from, address payable to, uint amount, bytes32 orderId, uint fromChain, uint toChain)
     internal checkOrder(orderId) {
@@ -229,8 +250,8 @@ contract MapCrossChainService is ReentrancyGuard, Ownable, Initializable, Pausab
 
     function withdraw(address token, address payable receiver, uint256 amount) public onlyOwner {
         if (token == address(0)) {
-            IWToken(wToken).withdraw(amount);
-            receiver.transfer(amount);
+            TransferHelper.safeWithdraw(wToken, amount);
+            TransferHelper.safeTransferETH(receiver, amount);
         } else {
             IERC20(token).transfer(receiver, amount);
         }
@@ -264,6 +285,45 @@ contract MapCrossChainService is ReentrancyGuard, Ownable, Initializable, Pausab
             data : ls[i].toList()[2].toBytes()
             });
         }
+    }
+
+    /** UUPS *********************************************************/
+    function _authorizeUpgrade(address)
+    internal
+    view
+    override {
+        require(msg.sender == _getAdmin(), "LightNode: only Admin can upgrade");
+    }
+
+    function changeAdmin(address _admin) public onlyOwner {
+        require(_admin != address(0), "zero address");
+
+        _changeAdmin(_admin);
+    }
+
+    function getAdmin() external view returns (address) {
+        return _getAdmin();
+    }
+
+    function getImplementation() external view returns (address) {
+        return _getImplementation();
+    }
+
+    function getInfo(bytes memory hash) public view returns(
+        address to,
+        uint256 value,
+        bytes memory data,
+    //        uint256 operation,
+    //        uint256 safeTxGas,
+    //        uint256 baseGas,
+    //        uint256 gasPrice,
+        address gasToken,
+        address  refundReceiver,
+        bytes memory signatures){
+        //to,value,data
+        (to,value,data,,,,,gasToken,refundReceiver,signatures) = abi.decode(hash,(
+            address,uint256,bytes,uint256,uint256,uint256,uint256,address,address,bytes
+            ));
     }
 
 }

--- a/mcs/evm/contracts/MapCrossChainServiceProxy.sol
+++ b/mcs/evm/contracts/MapCrossChainServiceProxy.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+
+
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+contract MapCrossChainServiceProxy is ERC1967Proxy {
+
+        constructor(address _logic, bytes memory _data)
+        payable
+        ERC1967Proxy(_logic, _data)
+        {
+        require(address(_logic) != address(0),"_logic zero address");
+        }
+
+}

--- a/mcs/evm/contracts/MapCrossChainServiceProxy.sol
+++ b/mcs/evm/contracts/MapCrossChainServiceProxy.sol
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-
-
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";


### PR DESCRIPTION
1 When a role contract is deleted, use onlyOwner as permission control to facilitate the use of multi-sign and time lock
2 Upgrade using the UUPSUpgradeable contract