### PR TITLE
update MCS contract on NEAR

### DIFF
--- a/mcs/near/scripts/manage_ft_token.sh
+++ b/mcs/near/scripts/manage_ft_token.sh
@@ -22,12 +22,12 @@ function list_tokens() {
 
 function transfer_out() {
   echo "transfer out $5 $1 token from $3 to $4 on chain $2"
-  near call $1 ft_transfer_call '{"receiver_id":"'$MCS_ACCOUNT'", "amount":"'$5'", "memo": "", "msg": "{\"msg_type\": 0, \"to\": '$4', \"to_chain\": '$2'}"}' --accountId $3 --depositYocto 1 --gas 60000000000000
+  near call $1 ft_transfer_call '{"receiver_id":"'$MCS_ACCOUNT'", "amount":"'$5'", "memo": "", "msg": "{\"msg_type\": 0, \"to\": '$4', \"to_chain\": \"'$2'\"}"}' --accountId $3 --depositYocto 1 --gas 60000000000000
 }
 
 function deposit_out() {
   echo "deposit out $4 $1 token from $2 to $3 on MAP chain"
-  near call $1 ft_transfer_call '{"receiver_id":"'$MCS_ACCOUNT'", "amount":"'$4'", "memo": "", "msg": "{\"msg_type\": 1, \"to\": '$3', \"to_chain\": 2}"}' --accountId $2 --depositYocto 1 --gas 60000000000000
+  near call $1 ft_transfer_call '{"receiver_id":"'$MCS_ACCOUNT'", "amount":"'$4'", "memo": "", "msg": "{\"msg_type\": 1, \"to\": '$3', \"to_chain\": \"0\"}"}' --accountId $2 --depositYocto 1 --gas 60000000000000
 }
 
 function balance() {

--- a/mcs/near/scripts/manage_mcs_token.sh
+++ b/mcs/near/scripts/manage_mcs_token.sh
@@ -29,13 +29,13 @@ function list_tokens() {
 
 function transfer_out() {
   echo "transfer out $5 $1 token from $3 to $4 on chain $2"
-  near call $MCS_ACCOUNT transfer_out_token '{"token":"'$1'", "to":'$4', "amount":"'$5'", "to_chain":'$2'}' --accountId $3 --gas 60000000000000
+  near call $MCS_ACCOUNT transfer_out_token '{"token":"'$1'", "to":'$4', "amount":"'$5'", "to_chain":"'$2'"}' --accountId $3 --gas 60000000000000
 
 }
 
 function deposit_out() {
   echo "deposit out $4 $1 token from $2 to $3 on MAP chain"
-  near call $1 ft_transfer_call '{"receiver_id":"'$MCS_ACCOUNT'", "amount":"'$4'", "memo": "", "msg": "{\"msg_type\": 1, \"to\": '$3', \"to_chain\": 1}"}' --accountId $2 --depositYocto 1 --gas 60000000000000
+  near call $MCS_ACCOUNT deposit_out_token '{"token":"'$1'", "to":'$3', "amount":"'$4'"}' --accountId $2 --gas 60000000000000
 }
 
 function balance() {

--- a/mcs/near/scripts/manage_multisig.sh
+++ b/mcs/near/scripts/manage_multisig.sh
@@ -45,7 +45,7 @@ function prepare_request() {
         echo "adding native token to_chain $2 to mcs contract"
         RECEIVER=$MCS_ACCOUNT
         METHOD="add_native_to_chain"
-        ARGS=`echo '{"to_chain": '$2'}'| base64`
+        ARGS=`echo '{"to_chain": "'$2'"}'| base64`
         MEMBER=$3
       else
         printHelp
@@ -57,7 +57,7 @@ function prepare_request() {
         echo "add mcs token $2 to_chain $3 to mcs contract"
         RECEIVER=$MCS_ACCOUNT
         METHOD="add_mcs_token_to_chain"
-        ARGS=`echo '{"token": "'$2'", "to_chain": '$3'}'| base64`
+        ARGS=`echo '{"token": "'$2'", "to_chain": "'$3'"}'| base64`
         MEMBER=$4
       else
         printHelp
@@ -69,7 +69,7 @@ function prepare_request() {
         echo "add ft token $2 to_chain $3 to mcs contract"
         RECEIVER=$MCS_ACCOUNT
         METHOD="add_fungible_token_to_chain"
-        ARGS=`echo '{"token": "'$2'", "to_chain": '$3'}'| base64`
+        ARGS=`echo '{"token": "'$2'", "to_chain": "'$3'"}'| base64`
         MEMBER=$4
       else
         printHelp
@@ -81,7 +81,7 @@ function prepare_request() {
         echo "remove native token to_chain $2 from mcs contract"
         RECEIVER=$MCS_ACCOUNT
         METHOD="remove_native_to_chain"
-        ARGS=`echo '{"to_chain": '$2'}'| base64`
+        ARGS=`echo '{"to_chain": "'$2'"}'| base64`
         MEMBER=$3
       else
         printHelp
@@ -93,7 +93,7 @@ function prepare_request() {
         echo "remove mcs token $2 to_chain $3 from mcs contract"
         RECEIVER=$MCS_ACCOUNT
         METHOD="remove_mcs_token_to_chain"
-        ARGS=`echo '{"token": "'$2'", "to_chain": '$3'}'| base64`
+        ARGS=`echo '{"token": "'$2'", "to_chain": "'$3'"}'| base64`
         MEMBER=$3
       else
         printHelp
@@ -105,7 +105,7 @@ function prepare_request() {
         echo "remove ft token $2 to_chain $3 from mcs contract"
         RECEIVER=$MCS_ACCOUNT
         METHOD="remove_fungible_token_to_chain"
-        ARGS=`echo '{"token": "'$2'", "to_chain": '$3'}'| base64`
+        ARGS=`echo '{"token": "'$2'", "to_chain": "'$3'"}'| base64`
         MEMBER=$4
       else
         printHelp
@@ -129,7 +129,7 @@ function prepare_request() {
         echo "set chain type of chain $2 to $3"
         RECEIVER=$MCS_ACCOUNT
         METHOD="set_chain_type"
-        ARGS=`echo '{"chain_id": '$2', "chain_type": "'$3'"}'| base64`
+        ARGS=`echo '{"chain_id": "'$2'", "chain_type": "'$3'"}'| base64`
         MEMBER=$4
       else
         printHelp

--- a/mcs/near/scripts/manage_native_token.sh
+++ b/mcs/near/scripts/manage_native_token.sh
@@ -22,7 +22,7 @@ function list_to_chains() {
 
 function transfer_out() {
   echo "transfer out $4 amount near from $2 to $3 on chain $1"
-  near call $MCS_ACCOUNT transfer_out_native '{ "to":'$3', "to_chain": '$1'}' --accountId $2 --depositYocto $4 --gas 100000000000000
+  near call $MCS_ACCOUNT transfer_out_native '{ "to":'$3', "to_chain": "'$1'"}' --accountId $2 --depositYocto $4 --gas 100000000000000
 }
 
 function deposit_out() {

--- a/mcs/near/scripts/test.sh
+++ b/mcs/near/scripts/test.sh
@@ -13,7 +13,8 @@ AMOUNT=100000000000000000000000
 FROM="pandarr.testnet"
 TO="[46,120,72,116,221,179,44,215,151,93,104,86,91,80,148,18,165,181,25,244]"
 #TO_CHAIN=34434
-TO_CHAIN=22776 # map
+#TO_CHAIN=22776 # map mainnet
+TO_CHAIN=212 # map testnet
 CHAIN_TYPE="EvmChain"
 
 function printHelp() {
@@ -87,25 +88,25 @@ function deinit() {
 
 function add_chain() {
   echo "setting chain type"
-  $SCRIPT_DIR/manage_multisig.sh request_and_confirm chain_type $TO_CHAIN $CHAIN_TYPE
+  $SCRIPT_DIR/manage_multisig.sh request_and_confirm chain_type $TO_CHAIN $CHAIN_TYPE ${MEMBERS[1]}
 
   echo "adding mcs token to_chain"
-  $SCRIPT_DIR/manage_multisig.sh request_and_confirm add_mcs $MCS_TOKEN $TO_CHAIN
+  $SCRIPT_DIR/manage_multisig.sh request_and_confirm add_mcs $MCS_TOKEN $TO_CHAIN ${MEMBERS[1]}
   $SCRIPT_DIR/manage_mcs_token.sh list
 
   echo "adding ft token to_chain"
-  $SCRIPT_DIR/manage_multisig.sh request_and_confirm add_ft $FT_TOKEN $TO_CHAIN
+  $SCRIPT_DIR/manage_multisig.sh request_and_confirm add_ft $FT_TOKEN $TO_CHAIN ${MEMBERS[1]}
   $SCRIPT_DIR/manage_ft_token.sh list
 
   echo "adding native token to_chain"
-  $SCRIPT_DIR/manage_multisig.sh request_and_confirm add_native $TO_CHAIN
+  $SCRIPT_DIR/manage_multisig.sh request_and_confirm add_native $TO_CHAIN ${MEMBERS[1]}
   $SCRIPT_DIR/manage_native_token.sh list
 }
 
 function prepare() {
   echo "preparing mcs token"
-  $SCRIPT_DIR/manage_mcs_token.sh deploy $MCS_TOKEN_NAME
-  $SCRIPT_DIR/manage_multisig.sh request_and_confirm metadata $MCS_TOKEN $DECIMALS
+  $SCRIPT_DIR/manage_mcs_token.sh deploy $MCS_TOKEN_NAME $FROM
+  $SCRIPT_DIR/manage_multisig.sh request_and_confirm metadata $MCS_TOKEN $DECIMALS ${MEMBERS[1]}
   $SCRIPT_DIR/manage_mcs_token.sh list
 
   echo "minting 100000000000000000000000 $MCS_TOKEN for account $FROM"


### PR DESCRIPTION
1. update chain id type to U128 in public interfaces
2. burn mcs token before deposit out
3. fix deposit not return issue when 2 txes in one block have same transfer in event