### PR TITLE
return specific error when get invalid to/to_chain_token or nonexiste…

### DIFF
--- a/mcs/near/map-cross-chain-service/src/event.rs
+++ b/mcs/near/map-cross-chain-service/src/event.rs
@@ -1,6 +1,6 @@
 use crate::prover::{Address, MapEvent, EthEventParams};
 use ethabi::ParamType;
-use near_sdk::{Balance, CryptoHash};
+use near_sdk::{Balance, CryptoHash, env};
 use near_sdk::serde::{Serialize, Deserialize};
 use map_light_client::proof::LogEntry;
 use rlp::{Encodable, RlpStream};
@@ -67,11 +67,15 @@ impl MapTransferOutEvent {
 
 impl std::fmt::Display for MapTransferOutEvent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let to = String::from_utf8(self.to.clone())
+            .unwrap_or_else(|_| env::panic_str(&*format!("invalid to address: {:?}", self.to)));
+        let to_chain_token = String::from_utf8(self.to_chain_token.clone())
+            .unwrap_or_else(|_| env::panic_str(&*format!("invalid to chain token address: {:?}", self.to_chain_token)));
         write!(
             f,
             "token: {:?}; from: {:?};  orderId: {}; fromChain: {}; toChain: {}; to: {}; amount: {}; toChainToken: {}",
             self.token, self.from, hex::encode(self.order_id), self.from_chain, self.to_chain,
-            String::from_utf8(self.to.clone()).unwrap(), self.amount, String::from_utf8(self.to_chain_token.clone()).unwrap()
+            to, self.amount, to_chain_token
         )
     }
 }


### PR DESCRIPTION
…nt to account

If the to account does not exist, the order id is also recorded in case someone creates the account and get the token.