### PR TITLE
update eth2 light client deploy script

### DIFF
--- a/lightclients/eth2/README.md
+++ b/lightclients/eth2/README.md
@@ -83,10 +83,8 @@ PRIVATE_KEY=
 URL=
 # eth mainnet 1 Goerli 5
 CHAIN_ID =
-# initialize the light client base on the trusted root. You can get the trusted root through the beacon chain API 
-# "/eth/v1/beacon/states/<state_id>/finality_checkpoints", and make sure the bootstrap of the root is not empty through
-# beacon chain API "/eth/v1/beacon/light_client/bootstrap/<root>"
-TRUSTED_BLOCK_ROOT=
+# initialize the light client with the information of this period
+PERIOD=
 ```
 
 The deployment script is located in `deploy/` folder. We can run the following commands to deploy.

--- a/lightclients/eth2/env-example.txt
+++ b/lightclients/eth2/env-example.txt
@@ -1,8 +1,8 @@
 # your private key on the blockchain the contracts will be deployed to
 PRIVATE_KEY=
-# beacon chain rpc url
+# beacon chain rpc url. The RPC should contain the light client API, suggest to use lodestar RPC
 URL=
 # 1 for eth mainnet, 5 for Goerli testnet
 CHAIN_ID =
-# initialize the light client base on the trusted root
-TRUSTED_BLOCK_ROOT=
+# initialize the light client with the information of this period
+PERIOD=


### PR DESCRIPTION
Use PERIOD instead of TRUSTED_BLOCK_ROOT to initialize the eth2 light client contract.