### PR TITLE
add verifyProofDataWithCache for eth2 light client

### DIFF
--- a/lightclients/eth2/contracts/MPTVerify.sol
+++ b/lightclients/eth2/contracts/MPTVerify.sol
@@ -2,8 +2,8 @@
 
 pragma solidity 0.8.7;
 
-import "./interface/IMPTVerify.sol";
-import "./lib/MPT.sol";
+import "@mapprotocol/protocol/contracts/interface/IMPTVerify.sol";
+import "@mapprotocol/protocol/contracts/lib/MPT.sol";
 
 contract MPTVerify is IMPTVerify {
     function verifyTrieProof(
@@ -12,14 +12,6 @@ contract MPTVerify is IMPTVerify {
         bytes[] memory proof,
         bytes memory node
     ) external pure override returns (bool) {
-        MPT.MerkleProof memory mp = MPT.MerkleProof({
-            expectedRoot: root,
-            key: key,
-            proof: proof,
-            keyIndex: 0,
-            proofIndex: 0,
-            expectedValue: node
-        });
-        return MPT.verifyTrieProof(mp);
+        return MPT.verify(node, key, proof, root);
     }
 }

--- a/lightclients/eth2/package-lock.json
+++ b/lightclients/eth2/package-lock.json
@@ -11,6 +11,7 @@
         "@lodestar/api": "^1.7.0",
         "@lodestar/config": "^1.7.0",
         "@lodestar/types": "^1.7.0",
+        "@mapprotocol/protocol": "^0.5.0",
         "@nomicfoundation/hardhat-chai-matchers": "^1.0.2",
         "@openzeppelin/contracts": "^4.6.0",
         "dotenv": "^16.0.0",
@@ -886,6 +887,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@mapprotocol/protocol": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@mapprotocol/protocol/-/protocol-0.5.0.tgz",
+      "integrity": "sha512-FthD/9PU/d5jn9wiUduUU6rmjCxeiqwyoBQzG6TC6xQImUjcA3JUSgNaJ5KgR6hYCxmd2s997AzmKZq6smZsgw==",
+      "dependencies": {
+        "@openzeppelin/contracts": "^4.5.0"
       }
     },
     "node_modules/@metamask/eth-sig-util": {
@@ -22354,6 +22363,14 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "@mapprotocol/protocol": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@mapprotocol/protocol/-/protocol-0.5.0.tgz",
+      "integrity": "sha512-FthD/9PU/d5jn9wiUduUU6rmjCxeiqwyoBQzG6TC6xQImUjcA3JUSgNaJ5KgR6hYCxmd2s997AzmKZq6smZsgw==",
+      "requires": {
+        "@openzeppelin/contracts": "^4.5.0"
       }
     },
     "@metamask/eth-sig-util": {

--- a/lightclients/eth2/package.json
+++ b/lightclients/eth2/package.json
@@ -6,6 +6,7 @@
     "@lodestar/api": "^1.7.0",
     "@lodestar/config": "^1.7.0",
     "@lodestar/types": "^1.7.0",
+    "@mapprotocol/protocol": "^0.5.0",
     "@nomicfoundation/hardhat-chai-matchers": "^1.0.2",
     "@openzeppelin/contracts": "^4.6.0",
     "dotenv": "^16.0.0",

--- a/lightclients/eth2/test/lightNode.ts
+++ b/lightclients/eth2/test/lightNode.ts
@@ -118,7 +118,7 @@ describe("LightNode", function () {
 
             await expect(
                 lightNode.initSyncCommitteePubkey(bootstrap.curSyncCommitteePubkeys[0])
-            ).to.be.revertedWith("contract is initialized!");
+            ).to.be.revertedWith("initialized!");
         });
 
         it("re-initialization should fail", async function () {


### PR DESCRIPTION
1. add verifyProofDataWithCache and finalizedState implementation for eth2 light client.
2. import files from @mapprotocol/protocol/contracts
3. simply some error messages to decrease contract size